### PR TITLE
Importing old exported histories failing

### DIFF
--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -74,6 +74,11 @@ class JobImportHistoryArchiveWrapper( object, UsesAnnotations ):
                 #
                 # Create history.
                 #
+                if not os.path.exists(os.path.join( archive_dir, 'history_attrs.txt')):
+                    dirs = os.listdir(archive_dir)
+                    for d in dirs:
+                        if os.path.isdir(os.path.join(archive_dir, d)):
+                                archive_dir = os.path.join(archive_dir, d)
                 history_attr_file_name = os.path.join( archive_dir, 'history_attrs.txt')
                 history_attr_str = read_file_contents( history_attr_file_name )
                 history_attrs = loads( history_attr_str )


### PR DESCRIPTION
I have exported histories on older versions of galaxy in order to keep them as backup. I can not import them anymore.

While exporting histories on older versions of galaxy (using the bioblend API) there was a subdirectory created at the base of the archive (Galaxy-History-<name of the history>/). This is not the format expected by the import history tool which expects all the data to be found on the base of the archive and the datasets in a 'datasets' subdirectory. This produces a 'history_attrs.txt' file not found error and the import fails.

The workaround implemented is to check for the existence of 'history_attrs.txt' on the base of the archive and if not found check for the existence in the subdirectory of the archive.

Cheers,
Cristian